### PR TITLE
Typos

### DIFF
--- a/Source/Children/Chapter3/chapter3.Rnw
+++ b/Source/Children/Chapter3/chapter3.Rnw
@@ -151,7 +151,7 @@ mean(StringNumObject$ChacterVect)
 
 The last bit of code we just saw will probably be confusing. Why do we have a dollar sign (\texttt{\$}) between the name of our data frame object name and the \textbf{CharacterVect} variable? The dollar sign is called the component selector.\index{R!component selector}\index{R!\$, component selector}\footnote{It's also sometimes called the element name operator.} It basically extracts a part--component--of an object. In the previous example it extracted the \textbf{CharacterVect} column from the {\emph{StringNumObject}} and fed it to the \texttt{mean} command, which tried (in this case unsuccessfully) to find its mean.
 
-We can Of course, use the component selector to create new objects with parts of other objects. Imagine that we have the {\emph{StringNumObject}} and want an object with only the information in the numbers column. Let's use the following code:
+We can, of course, use the component selector to create new objects with parts of other objects. Imagine that we have the {\emph{StringNumObject}} and want an object with only the information in the numbers column. Let's use the following code:
 
 <<Ch3CompSelect, echo=TRUE>>=
 NewNumeric <- StringNumObject$NumericVect
@@ -736,7 +736,7 @@ In the \texttt{Sweave} options menu you can also set which LaTeX typesetting eng
 
 \subsection{\emph{knitr} \& R}
 
-As {\emph{knitr}} is a regular R package, you can Of course, knit documents in R (or using the console in RStudio). All of the {\emph{knitr}} syntax in your markup document is the same as before, but instead of clicking a {\tt{Compile PDF}} or {\tt{knit HTML}} button use the {\tt{knit}} function.\index{R function!knit} To knit a hypothetical Markdown file {\emph{Example.Rmd}} you first use the \texttt{setwd} command to set the working directory (for more details see Chapter \ref{DirectoriesChapter}) to the folder where the {\emph{Example.Rmd}} file is located. In this example it is located on the desktop.\footnote{Using the directory name {\tt{$\sim$/Documents/}} is for Mac computers. Please use alternative syntax discussed in Chapter \ref{DirectoriesChapter} on other types of systems.}
+As {\emph{knitr}} is a regular R package, you can of course, knit documents in R (or using the console in RStudio). All of the {\emph{knitr}} syntax in your markup document is the same as before, but instead of clicking a {\tt{Compile PDF}} or {\tt{knit HTML}} button use the {\tt{knit}} function.\index{R function!knit} To knit a hypothetical Markdown file {\emph{Example.Rmd}} you first use the \texttt{setwd} command to set the working directory (for more details see Chapter \ref{DirectoriesChapter}) to the folder where the {\emph{Example.Rmd}} file is located. In this example it is located in the Documents folder.\footnote{Using the directory name {\tt{$\sim$/Documents/}} is for Mac computers. Please use alternative syntax discussed in Chapter \ref{DirectoriesChapter} on other types of systems.}
 
 <<Ch3RawKnitSetwd, echo=TRUE, eval=FALSE, tidy=FALSE>>=
 setwd("~/Documents/")
@@ -839,7 +839,7 @@ output:
 \end{kframe}
 \end{knitrout}
 
-\noindent Finally, if you want to output to one format with the default rendering style, For example, the HTML document, use \texttt{html\_document: default}.
+\noindent Finally, if you want to output to one format with the default rendering style, for example, the HTML document, use \texttt{html\_document: default}.
 
 \subsection*{Chapter summary}
 


### PR DESCRIPTION
Fixed what appeared to be accidental mid-sentence capitalizations.  Changed "Desktop" reference to "Documents folder" reference to be consistent with the code shown.